### PR TITLE
Add refresh tokens function

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Singpass.OidcHelper
 - nonce (later returned inside the JWT from token endpoint)
 
 - `getTokens (authCode: string, axiosRequestConfig?: AxiosRequestConfig) => Promise<TokenResponse>` - get back the tokens from SP token endpoint. Outputs TokenResponse, which is the input for getIdTokenPayload
+- `refreshTokens (refreshToken: string, axiosRequestConfig?: AxiosRequestConfig) => Promise<TokenResponse>` - get fresh tokens from SP token endpoint. Outputs TokenResponse, which is the input for getIdTokenPayload
 - `getIdTokenPayload(tokens: TokenResponse) => Promise<TokenPayload>` - decrypt and verify the JWT. Outputs TokenPayload, which is the input for extractNricAndUuidFromPayload
 - `extractNricAndUuidFromPayload(payload: TokenPayload) => { nric: string, uuid: string }` - finally, get the nric and WOG (Whole-of-government) UUID of the user from the ID Token TokenPayload
 

--- a/src/singpass/singpass-helper.ts
+++ b/src/singpass/singpass-helper.ts
@@ -115,6 +115,32 @@ export class OidcHelper {
 	}
 
 	/**
+	 * Get fresh tokens from Singpass endpoint. Note: This will fail if not on an IP whitelisted by SP.
+	 * Use getIdTokenPayload on returned Token Response to get the token payload
+	 */
+	public refreshTokens = async (refreshToken: string, axiosRequestConfig?: AxiosRequestConfig): Promise<TokenResponse> => {
+	  const params = {
+	    scope: "openid",
+	    grant_type: "refresh_token",
+	    client_id: this.clientID,
+	    client_secret: this.clientSecret,
+	    refresh_token: refreshToken,
+	  };
+	  const body = querystringUtil.stringify(params);
+
+	  const config = {
+	    headers: { "content-type": "application/x-www-form-urlencoded" },
+	    ...axiosRequestConfig,
+	  };
+	  const response = await this.axiosClient.post(this.tokenUrl, body, config);
+	  if (!response.data.id_token) {
+	    Logger.error("Failed to get ID token: invalid response data", response.data);
+	    throw new SingpassMyInfoError("Failed to get ID token");
+	  }
+	  return response.data;
+	}
+
+	/**
 	 * Decrypts the ID Token JWT inside the TokenResponse to get the payload
 	 * Use extractNricAndUuidFromPayload on the returned Token Payload to get the NRIC and UUID
 	 */


### PR DESCRIPTION
This PR adds in the ability to call the Singpass token endpoint with a refresh token instead of an auth code to support sliding sessions.