### PR TITLE
5.2.5 add proxyUrl keys to MyInfoHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelogs
 
+## 5.2.5
+
+- Added 3 optional keys to MyInfoHelper: proxyTokenUrl, proxyPersonUrl, proxyPersonBasicUrl to support proxying MyInfo calls without affecting signature generation
+
 ## 5.2.4
 
 - Update axios to 0.24.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "5.2.4",
+	"version": "5.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "5.2.4",
+	"version": "5.2.5",
 	"description": "Helper for building a Relying Party to integrate with Singpass OIDC and MyInfo person basic API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/myinfo/helper/myinfo-helper.ts
+++ b/src/myinfo/helper/myinfo-helper.ts
@@ -43,6 +43,9 @@ export interface MyInfoHelperConstructor {
 	overridePersonUrl?: string;
 	overridePersonBasicUrl?: string;
 	overrideProfileStatusUrl?: string;
+	proxyTokenUrl?: string;
+	proxyPersonUrl?: string;
+	proxyPersonBasicUrl?: string;
 }
 
 export interface TokenResponse {
@@ -90,6 +93,9 @@ export class MyInfoHelper implements IMyInfoHelper {
 	private readonly personUrl: string;
 	private readonly personBasicUrl: string;
 	private readonly profileStatusUrl: string;
+	private readonly proxyTokenUrl: string;
+	private readonly proxyPersonUrl: string;
+	private readonly proxyPersonBasicUrl: string;
 
 	private readonly redirectUri: string;
 
@@ -105,6 +111,9 @@ export class MyInfoHelper implements IMyInfoHelper {
 		this.personUrl = this.getUrl(props.overridePersonUrl, PERSON_BASE_URL, props.environment);
 		this.personBasicUrl = this.getUrl(props.overridePersonBasicUrl, PERSON_BASIC_BASE_URL, props.environment);
 		this.profileStatusUrl = this.getUrl(props.overrideProfileStatusUrl, PROFILE_STATUS_BASE_URL, props.environment);
+		this.proxyTokenUrl = props.proxyTokenUrl;
+		this.proxyPersonUrl = props.proxyPersonUrl;
+		this.proxyPersonBasicUrl = props.proxyPersonBasicUrl;
 
 		const requestProps: MyInfoRequestConstructor = {
 			appId: props.clientID,
@@ -155,7 +164,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 
 		let response: AxiosResponse<TokenResponse>;
 		try {
-			response = await this.myInfoRequest.post(this.tokenUrl, params);
+			response = await this.myInfoRequest.post(this.tokenUrl, params, this.proxyTokenUrl);
 		} catch (error) {
 			logger.error("Failed to get token from Myinfo", error);
 			throw error;
@@ -172,6 +181,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 	 */
 	public getPersonCommon = async<K extends keyof MyInfoComponents.Schemas.PersonCommon>(uinfin: string, attributes: string[]): Promise<Pick<MyInfoComponents.Schemas.PersonCommon, K>> => {
 		const url = `${this.personBasicUrl}/${uinfin}`;
+		const proxyUrl = `${this.proxyPersonBasicUrl}/${uinfin}`;
 		const params = {
 			client_id: this.clientID,
 			sp_esvcId: this.singpassEserviceID,
@@ -180,7 +190,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 
 		let response: AxiosResponse<string>;
 		try {
-			response = await this.myInfoRequest.get(url, params);
+			response = await this.myInfoRequest.get(url, params, null, proxyUrl);
 		} catch (error) {
 			logger.error("Error requesting for person-common data (JWE) from Myinfo", error);
 			throw error;
@@ -216,6 +226,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 		const uinfin = await this.extractUinfinFromAccessToken(accessToken);
 
 		const url = `${this.personUrl}/${uinfin}/`;
+		const proxyUrl = `${this.proxyPersonUrl}/${uinfin}/`;
 		const params = {
 			client_id: this.clientID,
 			sp_esvcId: this.singpassEserviceID,
@@ -224,7 +235,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 
 		let response: AxiosResponse<string>;
 		try {
-			response = await this.myInfoRequest.get(url, params, accessToken);
+			response = await this.myInfoRequest.get(url, params, accessToken, proxyUrl);
 		} catch (error) {
 			logger.error("Error requesting for person data from Myinfo", error);
 			throw error;

--- a/src/myinfo/helper/myinfo-request.ts
+++ b/src/myinfo/helper/myinfo-request.ts
@@ -35,6 +35,7 @@ export class MyInfoRequest {
 		uri: string,
 		queryParams?: { [key: string]: any },
 		accessToken?: string,
+		proxyUrl?: string
 	): Promise<AxiosResponse<T>> {
 		const cacheControl = "no-cache";
 		const headers = querystringUtil.parse(`Cache-Control=${cacheControl}`);
@@ -61,13 +62,15 @@ export class MyInfoRequest {
 				Authorization: accessToken ? `${authHeader},Bearer ${accessToken}` : authHeader,
 			},
 		};
-		const response = await this.axiosClient.get<T>(uri, requestConfig);
+		const url = proxyUrl || uri;
+		const response = await this.axiosClient.get<T>(url, requestConfig);
 		return response;
 	}
 
 	public async post<T>(
 		uri: string,
-		params: { [key: string]: any }
+		params: { [key: string]: any },
+		proxyUrl?: string
 	): Promise<AxiosResponse<T>> {
 		const cacheControl = "no-cache";
 		const contentType = "application/x-www-form-urlencoded";
@@ -95,8 +98,9 @@ export class MyInfoRequest {
 		};
 
 		const urlSeachParams = new URLSearchParams(params);
+		const url = proxyUrl || uri;
 
-		const response = await this.axiosClient.post<T>(uri, urlSeachParams.toString(), requestConfig);
+		const response = await this.axiosClient.post<T>(url, urlSeachParams.toString(), requestConfig);
 		return response;
 	}
 }


### PR DESCRIPTION
added 3 optional proxy url to support gateway flow which uses lambda integration. this preserves the original (correct) myinfo url which is used in signature generation otherwise the proxy request will be rejected by myinfo.