### PR TITLE
5.2.6 fix proxyUrl to not be constructed if not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelogs
 
+## 5.2.6
+
+- Fixed proxyUrl to not be constructed if not provided
+
 ## 5.2.5
 
 - Added 3 optional keys to MyInfoHelper: proxyTokenUrl, proxyPersonUrl, proxyPersonBasicUrl to support proxying MyInfo calls without affecting signature generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "5.2.5",
+	"version": "5.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "5.2.5",
+	"version": "5.2.6",
 	"description": "Helper for building a Relying Party to integrate with Singpass OIDC and MyInfo person basic API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/myinfo/helper/myinfo-helper.ts
+++ b/src/myinfo/helper/myinfo-helper.ts
@@ -181,7 +181,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 	 */
 	public getPersonCommon = async<K extends keyof MyInfoComponents.Schemas.PersonCommon>(uinfin: string, attributes: string[]): Promise<Pick<MyInfoComponents.Schemas.PersonCommon, K>> => {
 		const url = `${this.personBasicUrl}/${uinfin}`;
-		const proxyUrl = `${this.proxyPersonBasicUrl}/${uinfin}`;
+		const proxyUrl = this.proxyPersonBasicUrl ? `${this.proxyPersonBasicUrl}/${uinfin}` : "";
 		const params = {
 			client_id: this.clientID,
 			sp_esvcId: this.singpassEserviceID,
@@ -226,7 +226,7 @@ export class MyInfoHelper implements IMyInfoHelper {
 		const uinfin = await this.extractUinfinFromAccessToken(accessToken);
 
 		const url = `${this.personUrl}/${uinfin}/`;
-		const proxyUrl = `${this.proxyPersonUrl}/${uinfin}/`;
+		const proxyUrl = this.proxyPersonUrl ? `${this.proxyPersonUrl}/${uinfin}/` : "";
 		const params = {
 			client_id: this.clientID,
 			sp_esvcId: this.singpassEserviceID,


### PR DESCRIPTION
missed out check in the initial url construction to only be done if proxyUrl is provided.