### PR TITLE
Support child race mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelogs
 
+## x.x.x
+
+-   Support `race` and `secondaryrace` as mock param options for `childrenbirthrecords` in fake helper
+
 ## 8.5.0
 
--	NdiOidcHelper
-    -	Added `constructAuthorizationUrlV2`
-    -	Added `getUserInfo` and `ververifyUserInfo` to fetch myinfo data from NDI instead of MyInfo
-    -	Add deprecation warnings for `constructAuthorizationUrl`, `getIdTokenPayload` and `extractNricAndUuidFromPayload` to encourage using the full NDI PKCE flow
--	MyInfo
-	-	added v4 specs
+-   NdiOidcHelper
+    -   Added `constructAuthorizationUrlV2`
+    -   Added `getUserInfo` and `ververifyUserInfo` to fetch myinfo data from NDI instead of MyInfo
+    -   Add deprecation warnings for `constructAuthorizationUrl`, `getIdTokenPayload` and `extractNricAndUuidFromPayload` to encourage using the full NDI PKCE flow
+-   MyInfo
+    -   added v4 specs
 
 ## 8.4.7
 

--- a/src/myinfo/fake/__tests__/fake-helper.spec.ts
+++ b/src/myinfo/fake/__tests__/fake-helper.spec.ts
@@ -1,4 +1,4 @@
-import { MyInfoLifeStatusCode, MyInfoSexCode, MyInfoVehicleStatus } from "../../domain";
+import { MyInfoLifeStatusCode, MyInfoRaceCode, MyInfoSexCode, MyInfoVehicleStatus } from "../../domain";
 import {
 	FakeMyInfoHelper,
 	transformChildBirthRecord,
@@ -196,6 +196,8 @@ describe("FakeMyInfoHelper", () => {
 					tob: "",
 					sex: MyInfoSexCode.FEMALE,
 					lifestatus: MyInfoLifeStatusCode.ALIVE,
+					race: MyInfoRaceCode.ACHEHNESE,
+					secondaryrace: MyInfoRaceCode.ZIMBABWEAN,
 				},
 				{
 					birthcertno: "S9846203A",
@@ -206,6 +208,21 @@ describe("FakeMyInfoHelper", () => {
 					lifestatus: MyInfoLifeStatusCode.ALIVE,
 				},
 			];
+
+			it("should set race code correctly", () => {
+				const fakeHelper = new FakeMyInfoHelper();
+
+				const person = fakeHelper.getPersonBasic({
+					archetype: ProfileArchetype.MR_SG_FATHER_NORMAL_CHILDREN,
+					childrenoverridemode: OverrideMode.full,
+					childrenbirthrecords: mockChildrenbirthrecords,
+				});
+
+				expect(person.childrenbirthrecords[0].race).toStrictEqual({ code: "AJ", desc: "ACHEHNESE" });
+				expect(person.childrenbirthrecords[0].secondaryrace).toStrictEqual({ code: "ZW", desc: "ZIMBABWEAN" });
+				expect(person.childrenbirthrecords[1].race).toStrictEqual(undefined);
+				expect(person.childrenbirthrecords[1].secondaryrace).toStrictEqual(undefined);
+			});
 
 			describe("childrenoverridemode = full", () => {
 				it("should override all exisiting children of archetype if childrenbirthrecords is NOT empty", () => {

--- a/src/myinfo/fake/fake-helper.ts
+++ b/src/myinfo/fake/fake-helper.ts
@@ -673,6 +673,17 @@ export function transformChildBirthRecord(
 		},
 		dob: { value: isNaN(Date.parse(childbirthrecord.dob)) ? "2020-01-01" : childbirthrecord.dob },
 		tob: { value: childbirthrecord.tob || "0000" },
+		...(childbirthrecord.race
+			? { race: { code: childbirthrecord.race, desc: MyInfoRaceCode.fn.toEnumDesc(childbirthrecord.race) } }
+			: undefined),
+		...(childbirthrecord.secondaryrace
+			? {
+					secondaryrace: {
+						code: childbirthrecord.secondaryrace,
+						desc: MyInfoRaceCode.fn.toEnumDesc(childbirthrecord.secondaryrace),
+					},
+				}
+			: undefined),
 		unavailable: false,
 	} as MyInfoComponents.Schemas.Childrenbirthrecords;
 }

--- a/src/myinfo/fake/types.ts
+++ b/src/myinfo/fake/types.ts
@@ -52,6 +52,8 @@ export interface ChildrenBirthRecord {
 	tob?: string;
 	sex?: MyInfoSexCode;
 	lifestatus?: MyInfoLifeStatusCode;
+	race?: MyInfoRaceCode;
+	secondaryrace?: MyInfoRaceCode;
 }
 
 export interface CpfContributionHistory {


### PR DESCRIPTION
- support ability to set race and secondary race fields for the mock childrenbirthrecords
- the key/field is only set if specified