### PR TITLE
[MOL 21341][XZY] OIDC v5 Token Payload Types, Exports, and Version Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelogs
 
+## 9.1.0
+
+-   Add `NdiOidcHelperV2` implementing the Singpass v5 / FAPI 2.0 authorization flow (PAR + DPoP + PKCE)
+-   No breaking changes — existing `NdiOidcHelper` and all current exports remain unchanged
+-   Add `TokenPayloadV2`, `UserDataPayloadV2`, `SubAttributes` types for v5 token and userinfo payloads
+-   Add `DpopUtil` (`createDpopProof`) and `ParUtil` (`sendPushedAuthorizationRequest`, `AuthenticationContextType`)
+-   `UserDataPayloadV2` is defined in `shared-constants.ts`; v1 types `TokenPayload` and `UserDataPayload` are deprecated
+-   Bump `axios` to `~1.18.0` to fix vulnerabilities
+
 ## 9.0.6
 
 -   Bump dependencies to fix vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "9.0.6",
+	"version": "9.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@govtechsg/singpass-myinfo-oidc-helper",
-			"version": "9.0.6",
+			"version": "9.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@js-joda/core": "^5.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,28 +57,14 @@
 				"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -87,9 +73,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -97,22 +83,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
-			"integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.1",
-				"@babel/helper-compilation-targets": "^7.27.1",
-				"@babel/helper-module-transforms": "^7.27.1",
-				"@babel/helpers": "^7.27.1",
-				"@babel/parser": "^7.27.1",
-				"@babel/template": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -138,14 +124,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -155,14 +141,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -182,9 +168,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -192,29 +178,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -234,9 +220,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -244,9 +230,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -254,9 +240,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -264,27 +250,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
-			"integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -533,33 +519,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -567,14 +553,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -727,9 +713,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1398,6 +1384,17 @@
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1984,9 +1981,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2513,13 +2510,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/async": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2527,9 +2517,9 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
@@ -2709,9 +2699,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.12",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-			"integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+			"version": "2.10.37",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+			"integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2722,9 +2712,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -2766,9 +2756,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2786,11 +2776,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2916,9 +2906,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001782",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-			"integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3510,26 +3500,10 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/ejs": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-			"integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"jake": "^10.8.5"
-			},
-			"bin": {
-				"ejs": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.329",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-			"integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+			"version": "1.5.372",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+			"integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3915,9 +3889,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3986,9 +3960,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4263,29 +4237,6 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/filelist": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"minimatch": "^5.0.1"
-			}
-		},
-		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4375,16 +4326,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -4695,9 +4646,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -4872,14 +4823,10 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
 			"engines": {
 				"node": ">= 12"
 			}
@@ -5100,49 +5047,6 @@
 			},
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/jake": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-			"integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"async": "^3.2.3",
-				"chalk": "^4.0.2",
-				"filelist": "^1.0.4",
-				"minimatch": "^3.1.2"
-			},
-			"bin": {
-				"jake": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jake/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/jake/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/jest": {
@@ -5860,10 +5764,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -5871,12 +5785,6 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
-		},
-		"node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"license": "MIT"
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
 			"version": "7.1.1",
@@ -6906,11 +6814,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.36",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"version": "2.0.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+			"integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nonce": {
 			"version": "1.0.4",
@@ -7806,9 +7717,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -7975,12 +7886,12 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-			"integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^9.0.5",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -8047,12 +7958,6 @@
 			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
 			"dev": true,
 			"license": "CC0-1.0"
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
@@ -8444,21 +8349,20 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.3.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
-			"integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
+			"version": "29.4.11",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
-				"ejs": "^3.1.10",
 				"fast-json-stable-stringify": "^2.1.0",
-				"jest-util": "^29.0.0",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.1",
-				"type-fest": "^4.39.1",
+				"semver": "^7.8.0",
+				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
 			"bin": {
@@ -8469,11 +8373,12 @@
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7.0.0-beta.0 <8",
-				"@jest/transform": "^29.0.0",
-				"@jest/types": "^29.0.0",
-				"babel-jest": "^29.0.0",
-				"jest": "^29.0.0",
-				"typescript": ">=4.3 <6"
+				"@jest/transform": "^29.0.0 || ^30.0.0",
+				"@jest/types": "^29.0.0 || ^30.0.0",
+				"babel-jest": "^29.0.0 || ^30.0.0",
+				"jest": "^29.0.0 || ^30.0.0",
+				"jest-util": "^29.0.0 || ^30.0.0",
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -8489,6 +8394,9 @@
 					"optional": true
 				},
 				"esbuild": {
+					"optional": true
+				},
+				"jest-util": {
 					"optional": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@js-joda/core": "^5.6.1",
 				"@js-joda/timezone": "^2.18.2",
-				"axios": "~1.15.0",
+				"axios": "~1.18.0",
 				"https-proxy-agent": "^7.0.3",
 				"is-base64": "^1.1.0",
 				"jsonwebtoken": "^9.0.2",
@@ -2517,14 +2517,40 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
+				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
 				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/axios/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/axios/node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@js-joda/core": "^5.6.1",
 		"@js-joda/timezone": "^2.18.2",
-		"axios": "~1.15.0",
+		"axios": "~1.18.0",
 		"https-proxy-agent": "^7.0.3",
 		"is-base64": "^1.1.0",
 		"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@govtechsg/singpass-myinfo-oidc-helper",
-	"version": "9.0.6",
+	"version": "9.1.0",
 	"description": "Helper for building a Relying Party to integrate with Singpass OIDC and MyInfo person basic API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/singpass/__tests__/singpass-helper-ndi-v2.spec.ts
+++ b/src/singpass/__tests__/singpass-helper-ndi-v2.spec.ts
@@ -3,6 +3,7 @@ import * as DpopUtil from "src/util/DpopUtil";
 import * as JweUtils from "src/util/JweUtil";
 import * as SigningUtil from "src/util/SigningUtil";
 import { NdiOidcHelperV2, NdiOidcHelperV2Constructor, TokenPayloadV2 } from "../singpass-helper-ndi-v2";
+import { AuthenticationContextType } from "src/util/ParUtil";
 
 const mockOidcConfigUrl = "https://stg-id.singpass.gov.sg/.well-known/openid-configuration";
 const mockClientId = "dNGEOSUjyJjTqytbxsspyJAyQIj3tyha";
@@ -121,7 +122,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should include optional Singpass-specific params when provided", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "proof", thumbprint: "tp" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "proof" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("assertion");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -136,7 +137,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 				userInfoScope: [],
 				codeVerifier: "test-code-verifier-43chars-minimum-length12",
 				redirectUriHttpsType: "app_claimed_https",
-				authenticationContextType: "APP_AUTHENTICATION_DEFAULT",
+				authenticationContextType: AuthenticationContextType.AppAuthenticationDefault,
 				authenticationContextMessage: "Log in to your account",
 				appLaunchUrl: "https://myapp.com/callback",
 				acrValues: "urn:singpass:authentication:loa:2",
@@ -151,7 +152,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should throw if PAR response is missing request_uri", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "proof", thumbprint: "tp" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "proof" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("assertion");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -171,9 +172,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should call createDpopProof with htm=POST and htu=PAR endpoint", async () => {
-			const dpopSpy = jest
-				.spyOn(DpopUtil, "createDpopProof")
-				.mockResolvedValue({ proof: "proof", thumbprint: "tp" });
+			const dpopSpy = jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "proof" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("assertion");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -218,7 +217,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 
 	describe("getTokens", () => {
 		it("should POST to token endpoint with DPoP header and code_verifier", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "token-dpop", thumbprint: "tp" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "token-dpop" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("token-assertion");
 
 			const mockTokenResponse = {
@@ -250,7 +249,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should throw if response is missing id_token", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p", thumbprint: "t" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("a");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -263,7 +262,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should throw if response is missing access_token", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p", thumbprint: "t" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("a");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -276,7 +275,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should call createDpopProof with htm=POST and htu=token endpoint", async () => {
-			const dpopSpy = jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p", thumbprint: "t" });
+			const dpopSpy = jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p" });
 			jest.spyOn(SigningUtil, "createClientAssertion").mockResolvedValue("a");
 
 			const postMock = jest.fn().mockResolvedValue({
@@ -301,7 +300,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 
 	describe("getUserInfo", () => {
 		it("should GET userinfo endpoint with DPoP header and DPoP authorization prefix", async () => {
-			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "userinfo-dpop", thumbprint: "tp" });
+			jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "userinfo-dpop" });
 
 			// Second GET is to userinfo endpoint
 			axiosMock.mockImplementationOnce(() => Promise.resolve({ status: 200, data: "encrypted-jwe-response" }));
@@ -322,7 +321,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 		});
 
 		it("should call createDpopProof with htm=GET, htu=userinfo endpoint, and accessToken", async () => {
-			const dpopSpy = jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p", thumbprint: "t" });
+			const dpopSpy = jest.spyOn(DpopUtil, "createDpopProof").mockResolvedValue({ proof: "p" });
 
 			axiosMock.mockImplementationOnce(() => Promise.resolve({ status: 200, data: "response" }));
 

--- a/src/singpass/__tests__/singpass-helper-ndi-v2.spec.ts
+++ b/src/singpass/__tests__/singpass-helper-ndi-v2.spec.ts
@@ -390,7 +390,7 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 	// =========================================================================
 
 	describe("verifyUserInfo", () => {
-		it("should decrypt, verify, and return person_info from the response", async () => {
+		it("should decrypt, verify, and return the person_info from the userinfo response", async () => {
 			const mockPersonInfo = {
 				uinfin: { value: "S9000001B", source: "1", classification: "C", lastupdated: "2024-09-26" },
 				name: { value: "SOH HAO FENG", source: "1", classification: "C", lastupdated: "2024-09-26" },
@@ -415,7 +415,6 @@ describe("NDI Singpass Helper V2 (FAPI 2.0)", () => {
 
 			const result = await helper.verifyUserInfo("encrypted-jwe-userinfo");
 
-			// V2 returns only person_info, not the full payload
 			expect(result).toEqual(mockPersonInfo);
 		});
 	});

--- a/src/singpass/shared-constants.ts
+++ b/src/singpass/shared-constants.ts
@@ -6,6 +6,9 @@ export interface TokenResponse {
 	id_token: string;
 }
 
+/**
+ * @deprecated Use {@link TokenPayloadV2} for Singpass v5 (FAPI 2.0) integrations.
+ */
 export interface TokenPayload {
 	rt_hash: string;
 	nonce?: string;
@@ -19,6 +22,9 @@ export interface TokenPayload {
 	amr: string[];
 }
 
+/**
+ * @deprecated Use {@link UserDataPayloadV2} for Singpass v5 (FAPI 2.0) integrations.
+ */
 export interface UserDataPayload extends MyInfoComponentsV4.Schemas.Person {
 	iat: number;
 	iss: string;

--- a/src/singpass/shared-constants.ts
+++ b/src/singpass/shared-constants.ts
@@ -25,3 +25,44 @@ export interface UserDataPayload extends MyInfoComponentsV4.Schemas.Person {
 	sub: string;
 	aud: string;
 }
+
+// =============================================================================
+// V2 (FAPI 2.0 / Singpass v5) types
+// =============================================================================
+
+// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/4.-parsing-the-id-token#the-sub_attributes-claim
+export interface SubAttributes {
+	account_type?: "standard" | "foreign";
+	identity_number?: string;
+	identity_coi?: string;
+	name?: string;
+	email?: string;
+	mobileno?: string;
+}
+
+// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/4.-parsing-the-id-token#jwt-claims
+export interface TokenPayloadV2 {
+	sub: string; // UUID only (no longer s=NRIC,u=UUID format)
+	sub_type: string;
+	sub_attributes?: SubAttributes;
+	act?: {
+		sub: string;
+		sub_attributes?: SubAttributes;
+	};
+	aud: string;
+	iss: string;
+	iat: number;
+	exp: number;
+	amr: string[];
+	acr?: string;
+	nonce?: string;
+}
+
+// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/5.-requesting-for-userinfo#successful-response
+export interface UserDataPayloadV2 {
+	person_info: MyInfoComponentsV4.Schemas.Person; // person data nested under person_info wrapper (v5)
+	iss: string;
+	sub: string;
+	aud: string;
+	iat: number;
+}

--- a/src/singpass/shared-constants.ts
+++ b/src/singpass/shared-constants.ts
@@ -60,8 +60,8 @@ export interface TokenPayloadV2 {
 	iat: number;
 	exp: number;
 	amr: string[];
-	acr?: string;
-	nonce?: string;
+	acr: string;
+	nonce: string;
 }
 
 // ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/5.-requesting-for-userinfo#successful-response

--- a/src/singpass/singpass-helper-ndi-v2.ts
+++ b/src/singpass/singpass-helper-ndi-v2.ts
@@ -15,9 +15,10 @@ import {
 } from "src/util/ParUtil";
 import { createClientAssertion } from "src/util/SigningUtil";
 import { MyInfoComponentsV4 } from "../types";
-import { TokenResponse } from "./shared-constants";
+import { TokenPayloadV2, TokenResponse, UserDataPayloadV2 } from "./shared-constants";
 
 export type { PARRequestParams, PARResponse };
+export type { SubAttributes, TokenPayloadV2, UserDataPayloadV2 } from "./shared-constants";
 
 // =============================================================================
 // Types
@@ -50,43 +51,6 @@ export interface TokenRequestBody {
 	client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 	client_assertion: string;
 	code_verifier: string;
-}
-
-// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/4.-parsing-the-id-token#jwt-claims
-export interface TokenPayloadV2 {
-	sub: string;
-	sub_type: string;
-	sub_attributes?: SubAttributes;
-	act?: {
-		sub: string;
-		sub_attributes?: SubAttributes;
-	};
-	aud: string;
-	iss: string;
-	iat: number;
-	exp: number;
-	amr: string[];
-	acr: string;
-	nonce: string;
-}
-
-// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/4.-parsing-the-id-token#the-sub_attributes-claim
-export interface SubAttributes {
-	account_type?: "standard" | "foreign";
-	identity_number?: string;
-	identity_coi?: string;
-	name?: string;
-	email?: string;
-	mobileno?: string;
-}
-
-// ref: https://docs.developer.singpass.gov.sg/docs/technical-specifications/integration-guide/5.-requesting-for-userinfo#successful-response
-export interface UserInfoPayloadV2 {
-	person_info: MyInfoComponentsV4.Schemas.Person;
-	iss: string;
-	sub: string;
-	aud: string;
-	iat: number;
 }
 
 // =============================================================================
@@ -311,7 +275,7 @@ export class NdiOidcHelperV2 {
 
 			try {
 				const verified = await JweUtil.verifyJwsUsingKeyStore(jwsPayload, keys);
-				const payload = JSON.parse(verified.payload.toString()) as UserInfoPayloadV2;
+				const payload = JSON.parse(verified.payload.toString()) as UserDataPayloadV2;
 
 				return payload.person_info;
 			} catch (e) {

--- a/src/singpass/singpass-helper-ndi-v2.ts
+++ b/src/singpass/singpass-helper-ndi-v2.ts
@@ -14,8 +14,8 @@ import {
 	sendPushedAuthorizationRequest,
 } from "src/util/ParUtil";
 import { createClientAssertion } from "src/util/SigningUtil";
-import { MyInfoComponentsV4 } from "../types";
-import { TokenPayloadV2, TokenResponse, UserDataPayloadV2 } from "./shared-constants";
+import type { TokenPayloadV2, TokenResponse, UserDataPayloadV2 } from "./shared-constants";
+import { MyInfoComponentsV4 } from "src/types";
 
 export type { PARRequestParams, PARResponse };
 export type { SubAttributes, TokenPayloadV2, UserDataPayloadV2 } from "./shared-constants";
@@ -275,9 +275,8 @@ export class NdiOidcHelperV2 {
 
 			try {
 				const verified = await JweUtil.verifyJwsUsingKeyStore(jwsPayload, keys);
-				const payload = JSON.parse(verified.payload.toString()) as UserDataPayloadV2;
-
-				return payload.person_info;
+				const { person_info } = JSON.parse(verified.payload.toString()) as UserDataPayloadV2;
+				return person_info;
 			} catch (e) {
 				logger.error("could not verify user info payload", e);
 				throw e;

--- a/src/util/ParUtil.ts
+++ b/src/util/ParUtil.ts
@@ -122,7 +122,7 @@ export interface PARConfig {
 export async function buildPARRequestParams(input: PARInput, config: PARConfig): Promise<PARRequestParams> {
 	const { clientID, redirectUri, issuer, clientAssertionSignKey } = config;
 
-	const scope = ["openid"].concat(input.userInfoScope).join(" ");
+	const scope = [...new Set(["openid", ...input.userInfoScope])].join(" ");
 
 	// Generate PKCE code_challenge from code_verifier
 	const codeChallenge = generators.codeChallenge(input.codeVerifier);

--- a/src/util/__tests__/ParUtil.spec.ts
+++ b/src/util/__tests__/ParUtil.spec.ts
@@ -1,7 +1,13 @@
 import { AxiosInstance } from "axios";
 import * as DpopUtil from "../DpopUtil";
 import * as SigningUtil from "../SigningUtil";
-import { constructAuthorizationUrl, PARConfig, PARInput, sendPushedAuthorizationRequest } from "../ParUtil";
+import {
+	constructAuthorizationUrl,
+	PARConfig,
+	PARInput,
+	sendPushedAuthorizationRequest,
+	AuthenticationContextType,
+} from "../ParUtil";
 
 describe("ParUtil", () => {
 	const mockConfig: PARConfig = {
@@ -99,6 +105,21 @@ describe("ParUtil", () => {
 			expect(body).toContain("scope=openid%20nationality%20noa");
 		});
 
+		it("should deduplicate openid if already included in userInfoScope", async () => {
+			const postMock = jest.fn().mockResolvedValue({
+				status: 200,
+				data: { request_uri: "urn:test", expires_in: 60 },
+			});
+			const config = { ...mockConfig, axiosClient: { post: postMock } as unknown as AxiosInstance };
+
+			await sendPushedAuthorizationRequest({ ...baseInput, userInfoScope: ["openid", "name"] }, config);
+
+			const body = postMock.mock.calls[0][1] as string;
+			// "openid" must appear exactly once — not "openid openid name"
+			expect(body).toContain("scope=openid%20name");
+			expect(body).not.toContain("openid%20openid");
+		});
+
 		it("should include optional Singpass-specific parameters when provided", async () => {
 			const postMock = jest.fn().mockResolvedValue({
 				status: 200,
@@ -110,7 +131,7 @@ describe("ParUtil", () => {
 				{
 					...baseInput,
 					redirectUriHttpsType: "app_claimed_https",
-					authenticationContextType: "APP_AUTHENTICATION_DEFAULT",
+					authenticationContextType: AuthenticationContextType.AppAuthenticationDefault,
 					authenticationContextMessage: "Log in to your account",
 					appLaunchUrl: "https://myapp.com/callback",
 					acrValues: "urn:singpass:authentication:loa:2",


### PR DESCRIPTION
## Summary

* Refactored NDI OIDC V2 type definitions
  * Updated `TokenPayloadV2` to make `acr` and `nonce` required fields
  * Added deprecation comments for V1 `TokenPayload` and related user info types
  * Improved user info handling logic

* Improved test coverage
  * Added and updated unit tests for refactored OIDC types and user info handling

* Security updates
  * Updated `axios` dependency to address vulnerabilities
  * Applied additional vulnerability fixes

* Release updates
  * Bumped package version to `9.1.0`
  * Updated `CHANGELOG` with release notes

## Testing
* Updated unit tests to validate new NDI OIDC V2 behavior
* Verified compatibility after type and dependency updates
